### PR TITLE
feature to raise issue to github when failure occur for oc job or build

### DIFF
--- a/package-build-controller/clients/jobs.py
+++ b/package-build-controller/clients/jobs.py
@@ -5,10 +5,11 @@ import logging
 
 def get_job_endpoint(req_url, namespace, job_name=None):
     if job_name:
-        return '{}/apis/batch/v1/namespaces/{}/jobs/{}'.format(req_url, namespace,
-                                                               job_name)
+        return "{}/apis/batch/v1/namespaces/{}/jobs/{}".format(
+            req_url, namespace, job_name
+        )
     else:
-        return '{}/apis/batch/v1/namespaces/{}/jobs'.format(req_url, namespace)
+        return "{}/apis/batch/v1/namespaces/{}/jobs".format(req_url, namespace)
 
 
 def get_job(req_url, req_headers, namespace, job_name=None):
@@ -19,6 +20,15 @@ def get_job(req_url, req_headers, namespace, job_name=None):
         return True, response.json()
     else:
         # logging.error("Error for get_job GET request: {}".format(response.json()))
+        return False, response.json()
+
+
+def get_all_pods(req_url, req_headers, namespace):
+    endpoint = "{}/api/v1/namespaces/{}/pods".format(req_url, namespace)
+    response = requests.get(endpoint, headers=req_headers, verify=False)
+    if response.status_code == 200:
+        return True, response.json()
+    else:
         return False, response.json()
 
 
@@ -55,6 +65,21 @@ def update_job(req_url, req_headers, namespace, job, job_name):
         return False
 
 
-if __name__ == '__main__':
+def get_job_logs(req_url, req_headers, namespace, job_pod):
+    job_pod_endpoint = "{}/api/v1/namespaces/{}/pods/{}/log".format(
+        req_url, namespace, job_pod
+    )
+    response = requests.get(job_pod_endpoint, headers=req_headers, verify=False)
+    if response.status_code == 200:
+        with open("{}.txt".format(job_pod), "w") as f:
+            f.write(response.text)
+        logging.debug("Log of {} {}".format(job_pod, response.text))
+        return True, response.text
+    else:
+        logging.error("Error for job pod log GET request: ".format(response.text))
+        return False, response.text
+
+
+if __name__ == "__main__":
     urllib3.disable_warnings()
     # get_job(OCP_URL, HEADERS, DEFAULT_NAMESPACE, job_name="tf-fedora27-build-job-27")

--- a/package-build-controller/misc/github_issue.py
+++ b/package-build-controller/misc/github_issue.py
@@ -1,0 +1,80 @@
+import os
+import json
+import random
+import requests
+
+
+def check_issue(g, title: str) -> bool:
+    """check if issue already exists upstream."""
+    for issue in g.json():
+        if issue.get("title") == title:
+            return True
+    return False
+
+
+def get_base_path(g):
+    """check if more pages are to be requested for upstream issues."""
+    if g.headers.get("Link"):
+        for next_link in g.headers.get("Link").split(","):
+            if 'rel="next"' in next_link.split(";")[1]:
+                return next_link.split(";")[0].strip("< >")
+            return None
+
+
+def get_upstream_issues(base_path: str, title: str) -> bool:
+    """parse through all upstream to check for already exsisting issues."""
+    while base_path:
+        g = requests.get(base_path)
+        if g.status_code == 200:
+            base_path = get_base_path(g)
+            if check_issue(g, title):
+                return True
+    return False
+
+
+def raise_issue(url: str, issue: json) -> int:
+    """raise the issue in github."""
+    r = requests.post(url, json.dumps(issue))
+    return r.status_code
+
+
+def get_github_token():
+    """fetch the required github token."""
+    with open(
+        os.path.join(os.path.dirname(__file__), "../plugins/tensorflow_config.json")
+    ) as f:
+        data = json.load(f)
+    return data.get("GIT_ISSUE_API_URL"), os.getenv("SESHETA_GITHUB_ACCESS_TOKEN")
+
+
+def get_expression():
+    """emoji to make the issue for humanlike."""
+    exp = [
+        ":collision: ",
+        ":exclamation: ",
+        ":dizzy_face: ",
+        ":scream: ",
+        ":loudspeaker: ",
+    ]
+    return random.choice(exp)
+
+
+def report_issue(entity_name, entity_status, detail="No Context"):
+    """report the failure as a github issue."""
+    apiurl, apitoken = get_github_token()
+    url = "{}?access_token={}".format(apiurl, apitoken)
+    title = "The {} has failed with status {}".format(entity_name, entity_status)
+    issue = {
+        "title": title,
+        "body": "{} **Failed Due to:**\n **Log:**\n ```\n{}```".format(
+            get_expression(), detail
+        ),
+        "labels": ["bug"],
+    }
+    issue_raised = get_upstream_issues(url, title)
+    if not issue_raised:
+        response_code = raise_issue(url, issue)
+        if response_code == 201:
+            return True
+        else:
+            return False

--- a/package-build-controller/misc/utils.py
+++ b/package-build-controller/misc/utils.py
@@ -1,8 +1,14 @@
 import json
 import os
 import threading
-from .const import SCHEMA, DEFAULT_NAMESPACE_FILE, DEFAULT_NAMESPACE ,ENV_NAMESPACE_FILE,\
-    SERVICE_TOKEN_FILENAME, SERVICE_CERT_FILENAME
+from .const import (
+    SCHEMA,
+    DEFAULT_NAMESPACE_FILE,
+    DEFAULT_NAMESPACE,
+    ENV_NAMESPACE_FILE,
+    SERVICE_TOKEN_FILENAME,
+    SERVICE_CERT_FILENAME,
+)
 
 
 def load_json_file(file_name):
@@ -22,7 +28,7 @@ def is_value_in_label(labels, value):
     if len(labels) == 0:
         return None
     if value in labels.values():
-            return value
+        return value
     else:
         return None
 
@@ -182,38 +188,44 @@ def flatten(lst):
 
 def get_api(typee):
     for x in flatten(SCHEMA):
-        if x['type'] == typee:
-            return x['api']
+        if x["type"] == typee:
+            return x["api"]
 
 
 def get_kind(typee):
     for x in flatten(SCHEMA):
-        if x['type'] == typee:
-            return x['kind']
+        if x["type"] == typee:
+            return x["kind"]
+
 
 def get_json_from_file(pfile, default=None):
     try:
         # 1) open file and extract value
-        with open(pfile, 'r') as f:
+        with open(pfile, "r") as f:
             return json.load(f)
     except FileNotFoundError as exc:
         if default:
             # 3) use the default value in constants.py
             return default
         else:
-            raise KeyError("default value not defined & json file: {} has issue.".format(exc))
+            raise KeyError(
+                "default value not defined & json file: {} has issue.".format(exc)
+            )
+
 
 def get_param_from_file(pfile, default=None):
     try:
         # 1) open file and extract value
-        with open(pfile, 'r') as f:
+        with open(pfile, "r") as f:
             return f.read()
     except FileNotFoundError as exc:
         if default:
             # 3) use the default value in constants.py
             return default
         else:
-            raise KeyError("default value not defined & file: {} not found.".format(exc))
+            raise KeyError(
+                "default value not defined & file: {} not found.".format(exc)
+            )
 
 
 def get_param_from_os(param):
@@ -232,10 +244,12 @@ def get_param_from_key(param, param_dict):
             # 2) get from config.json
             return param_dict.get(param.upper())
         else:
-            raise KeyError("{} default value not defined in env or in dict".format(param.upper()))
+            raise KeyError(
+                "{} default value not defined in env or in dict".format(param.upper())
+            )
 
 
-def get_param(param, param_dict,  default):
+def get_param(param, param_dict, default):
     try:
         # 1) all globals values maybe in the template.So pickup from environment
         return os.environ[param.upper()]
@@ -248,7 +262,11 @@ def get_param(param, param_dict,  default):
                 # 3) use the default value in constants.py
                 return default
             else:
-                raise KeyError("{} default value not defined in env or const.py".format(param.upper()))
+                raise KeyError(
+                    "{} default value not defined in env or const.py".format(
+                        param.upper()
+                    )
+                )
 
 
 def name(obj, calling_locals=locals()):
@@ -271,7 +289,9 @@ def _get_incluster_ca_file(ca_file=None):
 
 
 def get_namespace():
-    namespace_file = get_param(param=ENV_NAMESPACE_FILE, param_dict=None, default=DEFAULT_NAMESPACE_FILE)
+    namespace_file = get_param(
+        param=ENV_NAMESPACE_FILE, param_dict=None, default=DEFAULT_NAMESPACE_FILE
+    )
     namespace = get_param_from_file(namespace_file, DEFAULT_NAMESPACE)
     return namespace
 
@@ -279,7 +299,7 @@ def get_namespace():
 def get_namespace1(nfile):
     """Get namespace from namespace file."""
     try:
-        with open(nfile, 'r') as namespace:
+        with open(nfile, "r") as namespace:
             return namespace.read()
     except FileNotFoundError as exc:
         raise FileNotFoundError("Unable to get namespace from namespace file") from exc
@@ -288,26 +308,36 @@ def get_namespace1(nfile):
 def get_service_account_token():
     """Get token from service account token file."""
     try:
-        with open(_get_incluster_token_file(), 'r') as token_file:
+        with open(_get_incluster_token_file(), "r") as token_file:
             return token_file.read()
     except FileNotFoundError as exc:
-        raise FileNotFoundError("Unable to get service account token, please check "
-                                "that service has service account assigned with exposed token") from exc
+        raise FileNotFoundError(
+            "Unable to get service account token, please check "
+            "that service has service account assigned with exposed token"
+        ) from exc
 
 
 def get_header(api_key_dict):
     auth = api_key_dict["authorization"]
     header = {
-        'Content-Type': 'application/json',
-        'Authorization': auth,
-        'Accept': 'application/json',
-        'Connection': 'close'
+        "Content-Type": "application/json",
+        "Authorization": auth,
+        "Accept": "application/json",
+        "Connection": "close",
     }
     return header
 
 
+def get_job_pod(job_name, pod_json):
+    for meta_data in pod_json.get("items", []):
+        if job_name in meta_data["metadata"].get("name", ""):
+            return meta_data["metadata"].get("name")
+    return
+
+
 class ResourceCounter:
     """Thread-safe incrementing counter. """
+
     def __init__(self, initial=0):
         """Initialize a counter to given initial value (default 0)."""
         self.value = initial

--- a/package-build-controller/threads/event_thread.py
+++ b/package-build-controller/threads/event_thread.py
@@ -2,13 +2,23 @@ import logging
 from clients.resource_watch import test_endpoint
 from clients.build import get_buildconfig, get_build, get_build_logs
 from misc.const import PROCESS_RESOURCES, PLUGIN_BUILD_CONFIG_LABEL, PLUGIN_JOB_LABEL
-from clients.jobs import get_job
+from clients.jobs import get_job, get_job_logs, get_all_pods
 from kubernetes import client
-from misc.utils import is_value_in_label, get_value_in_label, get_job_status,\
-    get_build_status, get_namespace, get_header
+from misc.utils import (
+    is_value_in_label,
+    get_value_in_label,
+    get_job_status,
+    get_build_status,
+    get_namespace,
+    get_header,
+    get_job_pod,
+)
+from misc.github_issue import report_issue
 
 
-def process_new_event(resource_type, event_obj, bloom, object_map, task_q, global_count):
+def process_new_event(
+    resource_type, event_obj, bloom, object_map, task_q, global_count
+):
     host = client.Configuration().host
     api_key = client.Configuration().api_key
     namespace = get_namespace()
@@ -16,18 +26,26 @@ def process_new_event(resource_type, event_obj, bloom, object_map, task_q, globa
         # =========================
         # Process Failed Builds(init)
         # =========================
-        if is_build_failed(event_obj['status']):
-            build_config_name = get_value_in_label(event_obj['metadata']['labels'], "appName")
-            build_ver = int(event_obj['metadata']['name'][-1:])
-            bc_exist, bc_response = get_buildconfig(req_url=host, req_headers=get_header(api_key),
-                                                    namespace=namespace,
-                                                    build_config_name=build_config_name)
+        if is_build_failed(event_obj["status"]):
+            build_config_name = get_value_in_label(
+                event_obj["metadata"]["labels"], "appName"
+            )
+            build_ver = int(event_obj["metadata"]["name"][-1:])
+            bc_exist, bc_response = get_buildconfig(
+                req_url=host,
+                req_headers=get_header(api_key),
+                namespace=namespace,
+                build_config_name=build_config_name,
+            )
             if bc_exist:
-                latest_build_version = bc_response["status"]['lastVersion']
+                latest_build_version = bc_response["status"]["lastVersion"]
                 latest_build_id = int(latest_build_version)
-                b_exist, build_resp = get_build(req_url=host, req_headers=get_header(api_key),
-                                                namespace=namespace,
-                                                build_name='{}-{}'.format(build_config_name, str(latest_build_id)))
+                b_exist, build_resp = get_build(
+                    req_url=host,
+                    req_headers=get_header(api_key),
+                    namespace=namespace,
+                    build_name="{}-{}".format(build_config_name, str(latest_build_id)),
+                )
                 # -----------------------------------------------------
                 # build_ver | latest_build_id |    ACTION
                 # -----------------------------------------------------
@@ -37,151 +55,315 @@ def process_new_event(resource_type, event_obj, bloom, object_map, task_q, globa
                 # -----------------------------------------------------
                 if not (build_ver < latest_build_id):
                     # If no new builds are Running then trigger
-                    name = event_obj['metadata']['name']
+                    name = event_obj["metadata"]["name"]
                     bc_name = name[:-2]
                     ver = int(name[-1:])
                     # Do we know of the Build ?
                     if bc_name in object_map:
                         obj = object_map[bc_name]
-                        #print(obj)
+                        # print(obj)
                         ver = ver + 1
                         obj["spec"]["output"]["to"]["name"] = bc_name + ":" + str(ver)
-                        logging.debug('Adding new BuildConfig with version {} '.format(obj["spec"]["output"]["to"]["name"]))
-                        task_q.put({"kind": "BuildConfig", "object": obj, "trigger_count": 1, "retrigger": True})
+                        logging.debug(
+                            "Adding new BuildConfig with version {} ".format(
+                                obj["spec"]["output"]["to"]["name"]
+                            )
+                        )
+                        task_q.put(
+                            {
+                                "kind": "BuildConfig",
+                                "object": obj,
+                                "trigger_count": 1,
+                                "retrigger": True,
+                            }
+                        )
                         global_count.increment()
-                        logging.debug('Adding new BuildConfig {} G:{}'.format(obj["spec"]["output"]["to"]["name"], global_count))
+                        logging.debug(
+                            "Adding new BuildConfig {} G:{}".format(
+                                obj["spec"]["output"]["to"]["name"], global_count
+                            )
+                        )
                 else:
-                    logging.debug('Ignoring {}-{} since {}-{} found.'.format(build_config_name,
-                                                                                             build_ver,
-                                                                                             build_config_name,
-                                                                                             latest_build_id))
+                    logging.debug(
+                        "Ignoring {}-{} since {}-{} found.".format(
+                            build_config_name,
+                            build_ver,
+                            build_config_name,
+                            latest_build_id,
+                        )
+                    )
     elif resource_type == "jobs":
         # =========================
         # Process Failed Jobs(init)
         # =========================
-        if is_job_failed(event_obj['status']):
-            logging.debug('Ignoring new Job event {}.Let Job EVENT do processing '.format(event_obj["metadata"]["name"]))
+        if is_job_failed(event_obj["status"]):
+            logging.debug(
+                "Ignoring new Job event {}.Let Job EVENT do processing ".format(
+                    event_obj["metadata"]["name"]
+                )
+            )
     elif resource_type == "events":
-        if 'type' in event_obj:
-            if event_obj['object']['involvedObject']['name']:
-                #print("New EVENTS Object {} ".format(event_obj['object']['involvedObject']["kind"]))
+        if "type" in event_obj:
+            if event_obj["object"]["involvedObject"]["name"]:
+                # print("New EVENTS Object {} ".format(event_obj['object']['involvedObject']["kind"]))
                 # =========================
                 # EVENTS of type Pods
                 # =========================
-                name = event_obj['object']['involvedObject']['name']
-                if event_obj['object']['involvedObject']["kind"] == "Pod":
-                    name = name[:-len("-build")]
-                    ver = int(name.rsplit('-', 1)[1])
-                    bc_name = name.rsplit('-', 1)[0]
-                    status = event_obj['object']['reason']
-                    logging.debug("TODO - processing EVENTS Object of type Pod {} with status {}".format(name, status))
+                name = event_obj["object"]["involvedObject"]["name"]
+                if event_obj["object"]["involvedObject"]["kind"] == "Pod":
+                    name = name[: -len("-build")]
+                    ver = int(name.rsplit("-", 1)[1])
+                    bc_name = name.rsplit("-", 1)[0]
+                    status = event_obj["object"]["reason"]
+                    logging.debug(
+                        "TODO - processing EVENTS Object of type Pod {} with status {}".format(
+                            name, status
+                        )
+                    )
 
                 # =========================
                 # EVENTS of type Build
                 # =========================
-                elif event_obj['object']['involvedObject']["kind"] == "Build":
+                elif event_obj["object"]["involvedObject"]["kind"] == "Build":
                     name = name
-                    ver = int(name.rsplit('-', 1)[1])
-                    bc_name = name.rsplit('-', 1)[0]
-                    status = event_obj['object']['reason']
-                    logging.debug("processing EVENTS Object of type Build; {} with status {}; BuildConfig {}".format(name, status, bc_name))
-                    bc_exist, bc_response = get_buildconfig(req_url=host, req_headers=get_header(api_key),
-                                                            namespace=namespace,
-                                                            build_config_name=bc_name)
+                    ver = int(name.rsplit("-", 1)[1])
+                    bc_name = name.rsplit("-", 1)[0]
+                    status = event_obj["object"]["reason"]
+                    logging.debug(
+                        "processing EVENTS Object of type Build; {} with status {}; BuildConfig {}".format(
+                            name, status, bc_name
+                        )
+                    )
+                    bc_exist, bc_response = get_buildconfig(
+                        req_url=host,
+                        req_headers=get_header(api_key),
+                        namespace=namespace,
+                        build_config_name=bc_name,
+                    )
 
                     if bc_exist:
-                        latest_build_version = bc_response["status"]['lastVersion']
+                        latest_build_version = bc_response["status"]["lastVersion"]
                         latest_build_id = int(latest_build_version)
-                        b_exist, build_resp = get_build(req_url=host, req_headers=get_header(api_key),
-                                                        namespace=namespace,
-                                                        build_name='{}-{}'.format(bc_name, str(latest_build_id)))
+                        b_exist, build_resp = get_build(
+                            req_url=host,
+                            req_headers=get_header(api_key),
+                            namespace=namespace,
+                            build_name="{}-{}".format(bc_name, str(latest_build_id)),
+                        )
 
                         if b_exist:
-                            build_status = build_resp.get('status')
+                            build_status = build_resp.get("status")
                             # if latest build is failed retrigger
                             if is_build_failed(build_status):
-                                seen = bloom.add([build_status['config']['kind'], build_status['config']['name'],
-                                                  build_status['phase']])
+                                seen = bloom.add(
+                                    [
+                                        build_status["config"]["kind"],
+                                        build_status["config"]["name"],
+                                        build_status["phase"],
+                                    ]
+                                )
                                 if not seen:
-                                    logging.debug('Build not seen {} Failed-status is {}'.format(bc_name, build_status['phase']))
+                                    logging.debug(
+                                        "Build not seen {} Failed-status is {}".format(
+                                            bc_name, build_status["phase"]
+                                        )
+                                    )
                                     latest_build_id += 1
                                     if bc_name in object_map:
                                         obj = object_map[bc_name]
-                                        #print(obj)
-                                        obj["spec"]["output"]["to"]["name"] = bc_name + ":" + str(latest_build_id)
-                                        logging.debug('Adding new BuildConfig to retrigger {} '.format(obj["spec"]["output"]["to"]["name"]))
-                                        task_q.put({"kind": "BuildConfig", "object": obj, "trigger_count": 1, "retrigger": True})
+                                        # print(obj)
+                                        obj["spec"]["output"]["to"]["name"] = (
+                                            bc_name + ":" + str(latest_build_id)
+                                        )
+                                        logging.debug(
+                                            "Adding new BuildConfig to retrigger {} ".format(
+                                                obj["spec"]["output"]["to"]["name"]
+                                            )
+                                        )
+                                        task_q.put(
+                                            {
+                                                "kind": "BuildConfig",
+                                                "object": obj,
+                                                "trigger_count": 1,
+                                                "retrigger": True,
+                                            }
+                                        )
                                 else:
-                                    logging.debug('Build seen {} Failed-status is {}'.format(bc_name, build_status['phase']))
-                                    build_pod_name = '{}-{}-build'.format(bc_name, latest_build_id)
-                                    pod_exist, logs = get_build_logs(req_url=host, req_headers=get_header(api_key),
-                                                                     namespace=namespace,
-                                                                     build_pod=build_pod_name)
-                                    if pod_exist and 'gpg: keyserver receive failed: Keyserver error' in logs:
+                                    logging.debug(
+                                        "Build seen {} Failed-status is {}".format(
+                                            bc_name, build_status["phase"]
+                                        )
+                                    )
+                                    build_pod_name = "{}-{}-build".format(
+                                        bc_name, latest_build_id
+                                    )
+                                    pod_exist, logs = get_build_logs(
+                                        req_url=host,
+                                        req_headers=get_header(api_key),
+                                        namespace=namespace,
+                                        build_pod=build_pod_name,
+                                    )
+                                    if report_issue(
+                                        bc_name, build_status["phase"], detail=logs
+                                    ):
+                                        logging.debug(
+                                            "The build {} status is {}. A GitHub Issue has been raised.".format(
+                                                bc_name, build_status["phase"]
+                                            )
+                                        )
+                                    else:
+                                        logging.debug(
+                                            "The build {} status is {}. Failed to raise a GitHub Issue. Please contact the admin".format(
+                                                bc_name, build_status["phase"]
+                                            )
+                                        )
+                                    if (
+                                        pod_exist
+                                        and "gpg: keyserver receive failed: Keyserver error"
+                                        in logs
+                                    ):
                                         obj = object_map[bc_name]
-                                        task_q.put({"kind": "BuildConfig", "object": obj, "trigger_count": 1, "retrigger": True})
+                                        task_q.put(
+                                            {
+                                                "kind": "BuildConfig",
+                                                "object": obj,
+                                                "trigger_count": 1,
+                                                "retrigger": True,
+                                            }
+                                        )
                                     else:
                                         global_count.decrement()
-                                        logging.debug('Build seen {} Failed-status is {} G:{}'.format(bc_name, build_status['phase']
-                                                                                                      , global_count))
+                                        logging.debug(
+                                            "Build seen {} Failed-status is {} G:{}".format(
+                                                bc_name,
+                                                build_status["phase"],
+                                                global_count,
+                                            )
+                                        )
 
                             else:
                                 # Build is COMPLETE
-                                # TODO get job status
-                                seen = bloom.add([build_status['config']['kind'], build_status['config']['name'],
-                                                  build_status['phase']])
+                                seen = bloom.add(
+                                    [
+                                        build_status["config"]["kind"],
+                                        build_status["config"]["name"],
+                                        build_status["phase"],
+                                    ]
+                                )
                                 if not seen and bc_name in object_map.keys():
-                                    #global_count.decrement()
-                                    logging.debug('{} The Build {} status is {} global_count={}.'.format(task_q.qsize(),
-                                                                                                         bc_name, build_status['phase'],
-                                                                                                         global_count))
+                                    # global_count.decrement()
+                                    logging.debug(
+                                        "{} The Build {} status is {} global_count={}.".format(
+                                            task_q.qsize(),
+                                            bc_name,
+                                            build_status["phase"],
+                                            global_count,
+                                        )
+                                    )
                                     job_name = bc_name.replace("image", "job")
-                                    jexist, jresp = get_job(req_url=host, req_headers=get_header(api_key),
-                                                            namespace=namespace,
-                                                            job_name=job_name)
+                                    jexist, jresp = get_job(
+                                        req_url=host,
+                                        req_headers=get_header(api_key),
+                                        namespace=namespace,
+                                        job_name=job_name,
+                                    )
                                     if not jexist:
                                         if job_name in object_map:
                                             job = object_map[job_name]
-                                            task_q.put({"kind": "Job", "object": job, "trigger_count": 0, "retrigger": False})
+                                            task_q.put(
+                                                {
+                                                    "kind": "Job",
+                                                    "object": job,
+                                                    "trigger_count": 0,
+                                                    "retrigger": False,
+                                                }
+                                            )
                                             global_count.increment()
-                                            logging.debug('{} The Build->Job {} does not exist.Adding it. G:{}.'.format(task_q.qsize(),
-                                                                                                             job_name,
-                                                                                                             global_count))
+                                            logging.debug(
+                                                "{} The Build->Job {} does not exist.Adding it. G:{}.".format(
+                                                    task_q.qsize(),
+                                                    job_name,
+                                                    global_count,
+                                                )
+                                            )
                                     else:
-                                        job_status = get_job_status(jresp.get('status'))
-                                        logging.debug('{} The Build->Job {} status is {}.G:{}.TODO.'.format(task_q.qsize(),
-                                                                                                            job_name,
-                                                                                                            job_status,
-                                                                                                            global_count))
+                                        job_status = get_job_status(jresp.get("status"))
+                                        logging.debug(
+                                            "{} The Build->Job {} status is {}.G:{}.".format(
+                                                task_q.qsize(),
+                                                job_name,
+                                                job_status,
+                                                global_count,
+                                            )
+                                        )
 
                 # =========================
                 # EVENTS of type Jobs
                 # =========================
-                elif event_obj['object']['involvedObject']["kind"] == "Job":
-                    job_name = event_obj['object']['involvedObject']['name']
-                    jbool, jresponse = get_job(req_url=host, req_headers=get_header(api_key),
-                                               namespace=namespace,
-                                               job_name=job_name)
+                elif event_obj["object"]["involvedObject"]["kind"] == "Job":
+                    job_name = event_obj["object"]["involvedObject"]["name"]
+                    jbool, jresponse = get_job(
+                        req_url=host,
+                        req_headers=get_header(api_key),
+                        namespace=namespace,
+                        job_name=job_name,
+                    )
+                    job_status = get_job_status(jresponse.get("status"))
 
-                    job_status = get_job_status(jresponse.get('status'))
+                    if job_status == "BackoffLimitExceeded":
+                        global_count.decrement()
+                        # Raising GitHub Issue
+                        _, pods_info = get_all_pods(
+                            req_url=host,
+                            req_headers=get_header(api_key),
+                            namespace=namespace,
+                        )
+                        job_pod_name = get_job_pod(job_name, pods_info)
+                        pod_exist, joblogs = get_job_logs(
+                            req_url=host,
+                            req_headers=get_header(api_key),
+                            namespace=namespace,
+                            job_pod=job_pod_name,
+                        )
+                        detail = "Due to BackoffLimitExceeded"
+                        if joblogs:
+                            detail = joblogs
+                        if report_issue(job_name, job_status, detail=detail):
+                            logging.debug(
+                                "{} The Job {} status is {} global_count={}. A GitHub Issue has been raised.".format(
+                                    task_q.qsize(), job_name, job_status, global_count
+                                )
+                            )
+                        else:
+                            logging.debug(
+                                "{} The Job {} status is {} global_count={}. Failed to raise a GitHub Issue. Please contact the admin".format(
+                                    task_q.qsize(), job_name, job_status, global_count
+                                )
+                            )
 
-                    if job_status == 'BackoffLimitExceeded':
-                        #TODO when this is backoff raise github issue.
+                    elif job_status == "Complete":
                         global_count.decrement()
-                        logging.debug('{} The Job {} status is {} global_count={}.TODO raise GitHub Issue.'.format(task_q.qsize(),
-                                                                                                   job_name, job_status, global_count))
-                    elif job_status == 'Complete':
-                        global_count.decrement()
-                        logging.debug('{} The Job {} status is {}. global_count={}.'.format(task_q.qsize(),
-                                                                                                   job_name, job_status, global_count))
+                        logging.debug(
+                            "{} The Job {} status is {}. global_count={}.".format(
+                                task_q.qsize(), job_name, job_status, global_count
+                            )
+                        )
                     else:
-                        #if active
-                        logging.debug('{} The Job {} status is {}.TODO.'.format(task_q.qsize(), job_name, job_status))
+                        # if active
+                        logging.debug(
+                            "{} The Job {} status is {}.TODO".format(
+                                task_q.qsize(), job_name, job_status
+                            )
+                        )
                         # print(json.dumps(event, indent=4, sort_keys=True))
 
 
 def is_build_failed(build_status):
-    return build_status['phase'] != "Complete" and build_status['phase'] not in ["Pending", "Running", "BuildStarted"]
+    return build_status["phase"] != "Complete" and build_status["phase"] not in [
+        "Pending",
+        "Running",
+        "BuildStarted",
+    ]
 
 
 def is_job_failed(job_status):
@@ -193,16 +375,21 @@ def is_job_failed(job_status):
         jstatus_reason = jresp_conditions[0]["reason"]
         return True, jstatus_reason
     else:
-        if 'active' in job_status:
-            return False, 'active'
+        if "active" in job_status:
+            return False, "active"
 
 
 def process_events(event, resource, bloom, object_map, task_q, global_count):
     # Only process events from resources in PROCESS_RESOURCES
-    if event['object']['involvedObject']["kind"] in PROCESS_RESOURCES:
-        m_message, seen_before, m_count = add_event_to_map(event=event, resource=resource, bloom=bloom)
-        logging.debug("EVENTS: seen-before: {} {} B:{} G:{}".format(seen_before, m_message, m_count,
-                                                                    global_count))
+    if event["object"]["involvedObject"]["kind"] in PROCESS_RESOURCES:
+        m_message, seen_before, m_count = add_event_to_map(
+            event=event, resource=resource, bloom=bloom
+        )
+        logging.debug(
+            "EVENTS: seen-before: {} {} B:{} G:{}".format(
+                seen_before, m_message, m_count, global_count
+            )
+        )
         if not seen_before:
             # if EVENT is new...i.e it is not seen by BloomFilter then process events.
             process_new_event("events", event, bloom, object_map, task_q, global_count)
@@ -214,21 +401,34 @@ def event_loop_init(bloom, object_map, task_q, global_count):
     host = client.Configuration().host
     api_key = client.Configuration().api_key
     namespace = get_namespace()
-    past_builds = test_endpoint(host=host, req_headers=get_header(api_key), namespace=namespace,
-                                resource=builds)
+    past_builds = test_endpoint(
+        host=host, req_headers=get_header(api_key), namespace=namespace, resource=builds
+    )
     logging.debug("PAST BUILDS : {}".format(len(past_builds.json()["items"])))
     for pbuild in past_builds.json()["items"]:
-        if is_value_in_label(pbuild['metadata']['labels'], object_map[PLUGIN_BUILD_CONFIG_LABEL]):
+        if is_value_in_label(
+            pbuild["metadata"]["labels"], object_map[PLUGIN_BUILD_CONFIG_LABEL]
+        ):
             mkey, mstatus, mcount = add_build_to_map(build=pbuild, map=bloom)
-            logging.debug("BUILDS : seen-before: {} {} B:{} G:{}".format(mstatus, mkey, mcount, global_count))
+            logging.debug(
+                "BUILDS : seen-before: {} {} B:{} G:{}".format(
+                    mstatus, mkey, mcount, global_count
+                )
+            )
             process_new_event("builds", pbuild, bloom, object_map, task_q, global_count)
     jobs = "jobs"
-    _, past_jobs = get_job(req_url=host, req_headers=get_header(api_key), namespace=namespace)
+    _, past_jobs = get_job(
+        req_url=host, req_headers=get_header(api_key), namespace=namespace
+    )
     logging.debug("PAST Jobs : {}".format(len(past_jobs["items"])))
     for pjob in past_jobs["items"]:
-        if is_value_in_label(pjob['metadata']['labels'], object_map[PLUGIN_JOB_LABEL]):
+        if is_value_in_label(pjob["metadata"]["labels"], object_map[PLUGIN_JOB_LABEL]):
             mkey, mstatus, mcount = add_job_to_map(job=pjob, map=bloom)
-            logging.debug("JOBS : seen-before: {} {} B:{} G:{}".format(mstatus, mkey, mcount, global_count))
+            logging.debug(
+                "JOBS : seen-before: {} {} B:{} G:{}".format(
+                    mstatus, mkey, mcount, global_count
+                )
+            )
             process_new_event("jobs", pjob, bloom, object_map, task_q, global_count)
 
 
@@ -236,66 +436,97 @@ def add_job_to_map(job, map):
     host = client.Configuration().host
     api_key = client.Configuration().api_key
     namespace = get_namespace()
-    job_exists, jresponse = get_job(req_url=host, req_headers=get_header(api_key), namespace=namespace,
-                                    job_name=job['metadata']['name'])
+    job_exists, jresponse = get_job(
+        req_url=host,
+        req_headers=get_header(api_key),
+        namespace=namespace,
+        job_name=job["metadata"]["name"],
+    )
     if job_exists:
-        job_status = get_job_status(jresponse.get('status'))
-        seen_before = map.add(["Job", job['metadata']['name'],
-             jresponse['metadata']['resourceVersion'],
-             job_status])
+        job_status = get_job_status(jresponse.get("status"))
+        seen_before = map.add(
+            [
+                "Job",
+                job["metadata"]["name"],
+                jresponse["metadata"]["resourceVersion"],
+                job_status,
+            ]
+        )
         message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
             "Job",
-            job['metadata']['name'],
-            jresponse['metadata']['resourceVersion'],
-            job_status)
-        logging.debug("JOBS :*seen-before: {} {} {} ".format(seen_before, message, map.count))
+            job["metadata"]["name"],
+            jresponse["metadata"]["resourceVersion"],
+            job_status,
+        )
+        logging.debug(
+            "JOBS :*seen-before: {} {} {} ".format(seen_before, message, map.count)
+        )
         if not seen_before:
             message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
                 "Job",
-                job['metadata']['name'],
-                job['metadata']['resourceVersion'],
-                get_job_status(job['status']))
+                job["metadata"]["name"],
+                job["metadata"]["resourceVersion"],
+                get_job_status(job["status"]),
+            )
 
-            seen_before = map.add(["Job", job['metadata']['name'],
-                              job['metadata']['resourceVersion'],
-                              get_job_status(job['status'])])
+            seen_before = map.add(
+                [
+                    "Job",
+                    job["metadata"]["name"],
+                    job["metadata"]["resourceVersion"],
+                    get_job_status(job["status"]),
+                ]
+            )
             return message, seen_before, map.count
         else:
             return message, seen_before, map.count
     else:
         return "", True, map.count
 
+
 def add_build_to_map(build, map):
     # print(event)
     message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
-            "Build",
-            build['metadata']['name'],
-            build['metadata']['resourceVersion'],
-            build['status']['phase'])
+        "Build",
+        build["metadata"]["name"],
+        build["metadata"]["resourceVersion"],
+        build["status"]["phase"],
+    )
     # print(message)
-    status = map.add(["Build", build['metadata']['name'],
-                      build['metadata']['resourceVersion'],
-                      build['status']['phase']])
+    status = map.add(
+        [
+            "Build",
+            build["metadata"]["name"],
+            build["metadata"]["resourceVersion"],
+            build["status"]["phase"],
+        ]
+    )
     return message, status, map.count
 
 
 def add_resource(event, map):
-    if 'type' in event:
+    if "type" in event:
         message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
-            event['object']['kind'],
-            event['object']['metadata']['name'],
-            event['object']['metadata']['resourceVersion'],
-            event['object']['status']['phase'])
-        status = map.add([event['object']['kind'], event['object']['metadata']['name'],
-                 event['object']['metadata']['resourceVersion'],
-                 event['object']['status']['phase']])
+            event["object"]["kind"],
+            event["object"]["metadata"]["name"],
+            event["object"]["metadata"]["resourceVersion"],
+            event["object"]["status"]["phase"],
+        )
+        status = map.add(
+            [
+                event["object"]["kind"],
+                event["object"]["metadata"]["name"],
+                event["object"]["metadata"]["resourceVersion"],
+                event["object"]["status"]["phase"],
+            ]
+        )
         return message, status, map.count
 
 
 def add_event_to_map(event, resource, bloom):
     if resource == "events":
-        if 'type' in event:
-            kind = event['object']['involvedObject']['kind']
+        if "type" in event:
+            kind = event["object"]["involvedObject"]["kind"]
             if kind == "Job":
                 return add_event_job_to_map(bloom, event)
             else:
@@ -308,36 +539,54 @@ def add_event_build_to_map(bloom, event):
     host = client.Configuration().host
     api_key = client.Configuration().api_key
     namespace = get_namespace()
-    build_exist, bresponse = get_build(req_url=host, req_headers=get_header(api_key), namespace=namespace,
-                                       build_name=event['object']['involvedObject']['name'])
+    build_exist, bresponse = get_build(
+        req_url=host,
+        req_headers=get_header(api_key),
+        namespace=namespace,
+        build_name=event["object"]["involvedObject"]["name"],
+    )
     if not build_exist:
         message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
-            event['object']['involvedObject']['kind'],
-            event['object']['involvedObject']['name'],
-            event['object']['involvedObject']['resourceVersion'],
-            event['object']['reason'])
+            event["object"]["involvedObject"]["kind"],
+            event["object"]["involvedObject"]["name"],
+            event["object"]["involvedObject"]["resourceVersion"],
+            event["object"]["reason"],
+        )
         # seen_before = bloom.add([event['object']['involvedObject']['kind'], event['object']['involvedObject']['name'],
         #                          event['object']['involvedObject']['resourceVersion'],
         #                          event['object']['reason']])
         return message, True, bloom.count
     else:
-        build_status = get_build_status(bresponse.get('status'))
-        seen_before = bloom.add([event['object']['involvedObject']['kind'], event['object']['involvedObject']['name'],
-                                 bresponse['metadata']['resourceVersion'], build_status])
+        build_status = get_build_status(bresponse.get("status"))
+        seen_before = bloom.add(
+            [
+                event["object"]["involvedObject"]["kind"],
+                event["object"]["involvedObject"]["name"],
+                bresponse["metadata"]["resourceVersion"],
+                build_status,
+            ]
+        )
         message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
-            event['object']['involvedObject']['kind'],
-            event['object']['involvedObject']['name'],
-            bresponse['metadata']['resourceVersion'], build_status)
+            event["object"]["involvedObject"]["kind"],
+            event["object"]["involvedObject"]["name"],
+            bresponse["metadata"]["resourceVersion"],
+            build_status,
+        )
         if not seen_before:
             message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
-                event['object']['involvedObject']['kind'],
-                event['object']['involvedObject']['name'],
-                event['object']['involvedObject']['resourceVersion'],
-                event['object']['reason'])
-            seen_before = bloom.add([event['object']['involvedObject']['kind'],
-                                     event['object']['involvedObject']['name'],
-                                     event['object']['involvedObject']['resourceVersion'],
-                                     event['object']['reason']])
+                event["object"]["involvedObject"]["kind"],
+                event["object"]["involvedObject"]["name"],
+                event["object"]["involvedObject"]["resourceVersion"],
+                event["object"]["reason"],
+            )
+            seen_before = bloom.add(
+                [
+                    event["object"]["involvedObject"]["kind"],
+                    event["object"]["involvedObject"]["name"],
+                    event["object"]["involvedObject"]["resourceVersion"],
+                    event["object"]["reason"],
+                ]
+            )
             return message, seen_before, bloom.count
         else:
             return message, seen_before, bloom.count
@@ -347,34 +596,58 @@ def add_event_job_to_map(bloom, event):
     host = client.Configuration().host
     api_key = client.Configuration().api_key
     namespace = get_namespace()
-    job_exist, jresponse = get_job(req_url=host, req_headers=get_header(api_key), namespace=namespace,
-                                   job_name=event['object']['involvedObject']['name'])
+    job_exist, jresponse = get_job(
+        req_url=host,
+        req_headers=get_header(api_key),
+        namespace=namespace,
+        job_name=event["object"]["involvedObject"]["name"],
+    )
     if not job_exist:
         message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
-            event['object']['involvedObject']['kind'],
-            event['object']['involvedObject']['name'],
-            event['object']['involvedObject']['resourceVersion'],
-            event['object']['reason'])
-        seen_before = bloom.add([event['object']['involvedObject']['kind'], event['object']['involvedObject']['name'],
-                                 event['object']['involvedObject']['resourceVersion'],
-                                 event['object']['reason']])
+            event["object"]["involvedObject"]["kind"],
+            event["object"]["involvedObject"]["name"],
+            event["object"]["involvedObject"]["resourceVersion"],
+            event["object"]["reason"],
+        )
+        seen_before = bloom.add(
+            [
+                event["object"]["involvedObject"]["kind"],
+                event["object"]["involvedObject"]["name"],
+                event["object"]["involvedObject"]["resourceVersion"],
+                event["object"]["reason"],
+            ]
+        )
         return message, seen_before, bloom.count
-    job_status = get_job_status(jresponse.get('status'))
-    seen_before = bloom.add([event['object']['involvedObject']['kind'], event['object']['involvedObject']['name'],
-                             jresponse['metadata']['resourceVersion'], job_status])
+    job_status = get_job_status(jresponse.get("status"))
+    seen_before = bloom.add(
+        [
+            event["object"]["involvedObject"]["kind"],
+            event["object"]["involvedObject"]["name"],
+            jresponse["metadata"]["resourceVersion"],
+            job_status,
+        ]
+    )
     message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
-        event['object']['involvedObject']['kind'],
-        event['object']['involvedObject']['name'],
-        jresponse['metadata']['resourceVersion'], job_status)
+        event["object"]["involvedObject"]["kind"],
+        event["object"]["involvedObject"]["name"],
+        jresponse["metadata"]["resourceVersion"],
+        job_status,
+    )
     if not seen_before:
         message = "Kind: {0}; Name: {1}; version:{2}; reason:{3}".format(
-            event['object']['involvedObject']['kind'],
-            event['object']['involvedObject']['name'],
-            event['object']['involvedObject']['resourceVersion'],
-            event['object']['reason'])
-        seen_before = bloom.add([event['object']['involvedObject']['kind'], event['object']['involvedObject']['name'],
-                                 event['object']['involvedObject']['resourceVersion'],
-                                 event['object']['reason']])
+            event["object"]["involvedObject"]["kind"],
+            event["object"]["involvedObject"]["name"],
+            event["object"]["involvedObject"]["resourceVersion"],
+            event["object"]["reason"],
+        )
+        seen_before = bloom.add(
+            [
+                event["object"]["involvedObject"]["kind"],
+                event["object"]["involvedObject"]["name"],
+                event["object"]["involvedObject"]["resourceVersion"],
+                event["object"]["reason"],
+            ]
+        )
         return message, seen_before, bloom.count
     else:
         return message, seen_before, bloom.count


### PR DESCRIPTION
PR contains a feature to raise the GitHub issue on openshift job/build failure.
- For Build failure:
   * When a build fails, the event thread checks for failure and when the failure is encountered, GitHub issue along with oc logs is raised on GitHub.
- For Job failure:
   * When a job fails, the event thread checks for failure and when the failure is encountered, GitHub issue along with oc logs is raised on GitHub.
   * As for openshift job the pods are generated with names like <job-name>+<6 random characters>, it's difficult to find the pod related to a job using openshift job APIs.
   * Openshift pod APIs are used to gather all pod and check for pod related to the job, using that logs are fetched for the job.

File Added: package-build-controller/misc/utils.py

Additional Info:
* Openshift python package could be used instead of openshift APIs.
* Getting pod logs for a required job could be resource intensive.